### PR TITLE
feat: Remove JPA from gatherers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ By default the server starts at port 8080.
 
 ## Develop endpoints
 
-This endpoints are only available in develop mode (develop profile), 
+This endpoints are only available in develop mode (develop spring profile), 
 and are disabled in production
 
 * Init exchange places: `/api/places/init`
@@ -46,10 +46,10 @@ main Dockerfile.
 
 ## Front end
 
-1. You need npm
+1. You need `npm`
 2. Execute in the `client` folder `npm run build`
 
-## Cronjobs
+## CronJobs
 
 The system query the data every 10 minutes, and are only enabled
 in production profile.
@@ -59,19 +59,20 @@ in production profile.
 This project is in an continuous delivery:
 
 1. The code is hosted in Github
-2. When a push occur, the [docker ci](https://hub.docker.com/r/avolpe/cotizacion/) is trigger 
+2. On a push (or a merge request), the [travis CI](https://travis-ci.org/aVolpe/cotizacion) is trigger 
    and a new image is generated (avolpe/cotizacion)
-3. A web hook is invoked to the server
+3. A web hook is invoked to the server (www.volpe.com.py)
 4. The server pull the new image and restart
 
 # Links
 
-* Current version: [https://www.volpe.com.py](https://www.volpe.com.py)
+* Current version: [https://cotizacion.volpe.com.py](https://cotizacion.volpe.com.py)
 
 # TODO
 
 - [x] Make the database a volume (now it restart every time)
-* [ ] Add a chart to show the exchange evolution
+- [ ] Add a chart to show the exchange evolution.
+- [ ] Add a map to show the shortest path to get the best exchange.
 
 # License
 

--- a/src/main/java/py/com/volpe/cotizacion/Cotizacion.java
+++ b/src/main/java/py/com/volpe/cotizacion/Cotizacion.java
@@ -18,7 +18,6 @@ public class Cotizacion {
 
     public static void main(String[] args) {
         SpringApplication.run(Cotizacion.class, args);
-
     }
 
     @Bean

--- a/src/main/java/py/com/volpe/cotizacion/GathererManager.java
+++ b/src/main/java/py/com/volpe/cotizacion/GathererManager.java
@@ -17,6 +17,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
+ * This is the main entry point of this application
+ * <p>
+ * This class is in charge of creating (and in a future to update) the place data,
+ * and later query the exchanges in every place.
+ *
  * @author Arturo Volpe
  * @since 5/2/18
  */
@@ -29,26 +34,50 @@ public class GathererManager {
     private final PlaceRepository placeRepository;
     private final QueryResponseRepository queryResponseRepository;
 
+    /**
+     * This is in charge of initializing the database (place and branches).
+     *
+     * @param code the code of the place, null for all places
+     * @return the list of places initialized
+     */
     public List<String> init(String code) {
         return doAction("INIT", code, this::getPlace);
     }
 
+    /**
+     * This is in charge of performing a exchange query over a place
+     *
+     * @param code the code of the place (in case we want to only query one place)
+     * @return the list of places with new data
+     */
     @CacheEvict(cacheNames = {"byIso", "isoList"}, allEntries = true)
     public List<String> doQuery(String code) {
         return doAction("GATHER", code, this::doQuery);
     }
 
-    private List<String> doAction(String operationName, String code, Consumer<Gatherer> action) {
+    /**
+     * Do an action on a Gatherer, the action is safe.
+     * <p>
+     * Safe in this context means that if the action throws an exception, the this method will
+     * handle and log the error, allowing subsequent invocations to work.
+     *
+     * @param name   the name of this operation, for logging purposes
+     * @param code   the code over which gatherer the action mus be done, null to do the operation over all.
+     * @param action the action to do
+     * @return a list with the codes of every gatherer where the action was performed successfully
+     */
+    private List<String> doAction(String name, String code, Consumer<Gatherer> action) {
 
-        log.info("{} Initializing", operationName);
-        Function<Gatherer, String> safeAction = g -> {
+        log.info("{} Initializing", name);
+
+        Function<Gatherer, String> safeAction = gatherer -> {
             try {
-                log.info("{} running on {}", operationName, g.getCode());
-                action.accept(g);
-                log.info("{} end ok on {}", operationName, g.getCode());
-                return g.getCode();
+                log.info("{} running on {}", name, gatherer.getCode());
+                action.accept(gatherer);
+                log.info("{} end ok on {}", name, gatherer.getCode());
+                return gatherer.getCode();
             } catch (Exception e) {
-                log.warn("{} The gatherer {} throws an exception", operationName, g.getCode(), e);
+                log.warn("{} The gatherer {} throws an exception", name, gatherer.getCode(), e);
                 return null;
             }
         };
@@ -60,18 +89,33 @@ public class GathererManager {
             toRet = gathererList.parallelStream().map(safeAction);
         }
 
-        log.info("{} end", operationName);
+        log.info("{} end", name);
         return toRet.filter(Objects::nonNull).collect(Collectors.toList());
 
     }
 
-    private void doQuery(Gatherer g) {
-        Place p = getPlace(g);
-        g.doQuery(p, p.getBranches())
+    /**
+     * Make a query in a gatherer
+     * <p>
+     * This methods is in charge of provides the correct parameters.
+     *
+     * @param gatherer the gatherer.
+     */
+    private void doQuery(Gatherer gatherer) {
+        Place p = getPlace(gatherer);
+        gatherer.doQuery(p, p.getBranches())
                 .forEach(queryResponseRepository::save);
     }
 
-    private Place getPlace(Gatherer g) {
-        return placeRepository.findByCode(g.getCode()).orElseGet(() -> placeRepository.save(g.build()));
+    /**
+     * Check if the place exists and if it doesn't, it create the place.
+     *
+     * @param gatherer the gatherer
+     * @return the persisted place
+     */
+    private Place getPlace(Gatherer gatherer) {
+        return placeRepository
+                .findByCode(gatherer.getCode())
+                .orElseGet(() -> placeRepository.save(gatherer.build()));
     }
 }

--- a/src/main/java/py/com/volpe/cotizacion/SwaggerConfig.java
+++ b/src/main/java/py/com/volpe/cotizacion/SwaggerConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
 import springfox.documentation.service.Contact;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
@@ -13,20 +14,24 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @Configuration
 @EnableSwagger2
 public class SwaggerConfig {
-	@Bean
-	public Docket api() {
-		return new Docket(DocumentationType.SWAGGER_2)
-				.select()
-				.apis(RequestHandlerSelectors.any())
-				.paths(PathSelectors.any())
-				.build()
-				.apiInfo(
-						new ApiInfoBuilder()
-								.license("MIT")
-								.title("Cotizaciones")
-								.version("1.0.0")
-								.contact(new Contact("Arturo Volpe", "https://www.volpe.com.py", "arturovolpe@gmail.com"))
-								.build()
-				);
-	}
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.any())
+                .build()
+                .apiInfo(buildInfo());
+    }
+
+    private ApiInfo buildInfo() {
+        return new ApiInfoBuilder()
+                .license("MIT")
+                .title("Cotizaciones")
+                .version("1.0.1")
+                .contact(new Contact("Arturo Volpe",
+                        "https://www.volpe.com.py",
+                        "arturovolpe@gmail.com"))
+                .build();
+    }
 }

--- a/src/main/java/py/com/volpe/cotizacion/domain/Place.java
+++ b/src/main/java/py/com/volpe/cotizacion/domain/Place.java
@@ -42,4 +42,10 @@ public class Place {
 
         this.branches.forEach(b -> b.setPlace(this));
     }
+
+    public void addBranch(PlaceBranch newBranch) {
+        if (this.branches == null) this.branches = new ArrayList<>();
+        newBranch.setPlace(this);
+        this.branches.add(newBranch);
+    }
 }

--- a/src/main/java/py/com/volpe/cotizacion/gatherer/Alberdi.java
+++ b/src/main/java/py/com/volpe/cotizacion/gatherer/Alberdi.java
@@ -15,6 +15,8 @@ import py.com.volpe.cotizacion.domain.QueryResponse;
 import py.com.volpe.cotizacion.domain.QueryResponseDetail;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -68,6 +70,12 @@ public class Alberdi implements Gatherer {
         return Long.parseLong(number.replace(".", ""));
     }
 
+    /**
+     * We read a file from the class path called "alberdi_branch_data", the file has the
+     * important information about all the branches
+     *
+     * @return the place
+     */
     @Override
     public Place build() {
 
@@ -76,83 +84,28 @@ public class Alberdi implements Gatherer {
 
         Place place = new Place("Cambios Alberdi", CODE);
 
-        Map<String, List<ExchangeData>> result = getParsedData();
+        Map<String, PlaceBranch> result = getBranchData();
 
-        result.keySet().forEach(name -> place.addBranch(buildBranch(name, place)));
+        place.setBranches(new ArrayList<>(result.values()));
 
         return place;
 
     }
 
-    private PlaceBranch buildBranch(String code, Place p) {
-        PlaceBranch.PlaceBranchBuilder pb = PlaceBranch.builder()
-                .name(code)
-                .remoteCode(code)
-                .place(p);
+    private Map<String, PlaceBranch> getBranchData() {
 
-        switch (code) {
-            case "asuncion":
-                return pb.name("Asunción")
-                        .latitude(-25.281411)
-                        .longitude(-57.6375917)
-                        .image("https://lh5.googleusercontent.com/p/AF1QipMxA2Nv-mtjAzqti1pUgd_Bt3z8nfbBBizklGEw=w408-h244-k-no")
-                        .phoneNumber("(021) 447.003 / (021) 447.004")
-                        .schedule("07:45 horas a 17:00 horas de Lunes a Viernes, 07:45 horas a 12:00 horas Sábados")
-                        .email("matriz@cambiosalberdi.com")
-                        .build();
-            case "villamorra":
-                return pb.name("Villa Morra")
-                        .phoneNumber("(021) 609.905 / (021) 609.906")
-                        .schedule("08:00 horas a 17:00 horas de Lunes a Viernes, 08:00 horas a 12:00 horas Sábados")
-                        .image("https://lh5.googleusercontent.com/p/AF1QipP9gq7gRfgXTFGdQFGJYWLZGq_9SSLJ_pKYN4Uk=w408-h306-k-no")
-                        .latitude(-25.2962143)
-                        .longitude(-57.5766948)
-                        .build();
-            case "sanlo":
-                return pb.name("San Lorenzo")
-                        .image("https://lh5.googleusercontent.com/p/AF1QipM0yx3fvWQArt0kY6EwyaaAsgX1jYRy3OuIobjr=w408-h725-k-no")
-                        .latitude(-25.3459184)
-                        .longitude(-57.5151255)
-                        .phoneNumber("(021) 571.215 / (021) 571.216")
-                        .schedule("08:00 horas a 17:00 horas de Lunes a Viernes, 08:00 horas a 12:00 horas Sábados")
-                        .build();
-            case "salto":
-                return pb.name("Salto del Guairá")
-                        .latitude(-24.055276)
-                        .longitude(-54.3246485)
-                        .phoneNumber("(046) 243.158 / (046) 243.159")
-                        .schedule("08:00 horas a 16:00 horas de Lunes a Viernes, 07:30 horas a 11:30 horas Sábados")
-                        .build();
-            case "cde":
-                return pb.name("Sucursal 1 CDE")
-                        .latitude(-25.5098204)
-                        .longitude(-54.6164127)
-                        .phoneNumber("(061) 500.135 / (061) 500.417")
-                        .schedule("07:00 horas a 17:00 horas de Lunes a Viernes, 07:00 horas a 12:00 horas Sábados")
-                        .build();
-            case "cde2":
-                return pb.name("CDE KM 4")
-                        .latitude(-25.5095271)
-                        .longitude(-54.6485326)
-                        .phoneNumber("(061) 571.540 / (061) 571.536")
-                        .schedule("07:00 horas a 17:00 horas de Lunes a Viernes, 07:00 horas a 12:00 horas Sábados")
-                        .build();
-            case "enc":
-                return pb.name("Encarnación")
-                        .latitude(-27.3314553)
-                        .longitude(-55.8670186)
-                        .image("https://lh5.googleusercontent.com/p/AF1QipOAtjZef_kGv14qJ4h68Rt4CKOxxwYXPJW30BUY=w408-h306-k-no")
-                        .schedule("07:45 horas a 17:00 horas de Lunes a Viernes, 07:45 horas a 12:00 horas Sábados")
-                        .phoneNumber("(071) 205.154 / (071) 205.120 / (071) 205.144")
-                        .build();
-            default:
-                log.warn("Unknown branch {} of {}", code, CODE);
-                return pb.build();
+        InputStream fileIS = getClass().getClassLoader().getResourceAsStream("alberdi_branch_data.json");
 
+        try {
+            return buildMapper()
+                    .readValue(fileIS, new TypeReference<Map<String, PlaceBranch>>() {
+                    });
+        } catch (IOException e) {
+            throw new AppException(500, "Can't read branch file", e);
         }
     }
 
-    Map<String, List<ExchangeData>> getParsedData() {
+    protected Map<String, List<ExchangeData>> getParsedData() {
         try {
             String queryResult = helper.getDataWithoutSending(WS_URL);
             return buildMapper()
@@ -185,6 +138,7 @@ public class Alberdi implements Gatherer {
                 return null;
         }
     }
+
 
     @Data
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/py/com/volpe/cotizacion/gatherer/Amambay.java
+++ b/src/main/java/py/com/volpe/cotizacion/gatherer/Amambay.java
@@ -14,7 +14,6 @@ import py.com.volpe.cotizacion.domain.QueryResponse;
 import py.com.volpe.cotizacion.domain.QueryResponseDetail;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -49,8 +48,7 @@ public class Amambay implements Gatherer {
 
             BranchExchangeData data = buildMapper().readValue(httpHelper.doGet(URL_CHANGE), BranchExchangeData.class);
 
-            qr.setDetails(data.getCurrencyExchanges().stream().map(BranchExchangeDetailsData::map).collect(Collectors.toList()));
-
+            data.getCurrencyExchanges().forEach(exchange -> qr.addDetail(exchange.map()));
 
             return qr;
 
@@ -62,13 +60,13 @@ public class Amambay implements Gatherer {
     @Override
     public Place build() {
 
-        Place p = new Place("Cambios Amambay", CODE);
+        Place place = new Place("Cambios Amambay", CODE);
 
-        PlaceBranch pb = PlaceBranch.builder().place(p).name("Central").build();
+        PlaceBranch centralBranch = PlaceBranch.builder().place(place).name("Central").build();
 
-        p.setBranches(Collections.singletonList(pb));
+        place.addBranch(centralBranch);
 
-        return p;
+        return place;
     }
 
     private ObjectMapper buildMapper() {

--- a/src/main/java/py/com/volpe/cotizacion/gatherer/Amambay.java
+++ b/src/main/java/py/com/volpe/cotizacion/gatherer/Amambay.java
@@ -53,7 +53,7 @@ public class Amambay implements Gatherer {
             return qr;
 
         } catch (IOException e) {
-            throw new AppException(500, "cant read response from chaco branch: " + branch.getId(), e);
+            throw new AppException(500, "cant read response from Amambay " + branch.getId(), e);
         }
     }
 

--- a/src/main/java/py/com/volpe/cotizacion/gatherer/Gatherer.java
+++ b/src/main/java/py/com/volpe/cotizacion/gatherer/Gatherer.java
@@ -1,6 +1,7 @@
 package py.com.volpe.cotizacion.gatherer;
 
 import py.com.volpe.cotizacion.domain.Place;
+import py.com.volpe.cotizacion.domain.PlaceBranch;
 import py.com.volpe.cotizacion.domain.QueryResponse;
 
 import java.util.List;
@@ -14,20 +15,20 @@ public interface Gatherer {
     /**
      * Query the data from this place.
      * <p>
-     * This method should store the data in the DB
-     * <p>
      * This method can trow exceptions.
      *
-     * @return the persisted list of data
+     * @return the result of the query
      */
-    List<QueryResponse> doQuery();
+    List<QueryResponse> doQuery(Place place, List<PlaceBranch> branches);
 
     /**
-     * Get the current place (search by CODE)
+     * Build the place in the current version.
+     * <p>
+     * This method don't persist the place.
      *
-     * @return the optional place
+     * @return the place
      */
-    Place get();
+    Place build();
 
 
     /**

--- a/src/main/java/py/com/volpe/cotizacion/gatherer/MaxiCambios.java
+++ b/src/main/java/py/com/volpe/cotizacion/gatherer/MaxiCambios.java
@@ -21,7 +21,6 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -46,25 +45,22 @@ public class MaxiCambios implements Gatherer {
         return branches.stream().map(branch -> {
             String url = branch.getRemoteCode().equals("0") ? WS_URL_AS : WS_URL_CDE;
 
-            QueryResponse qr = new QueryResponse();
-            qr.setBranch(branch);
-            qr.setPlace(place);
-            qr.setDate(new Date());
-            qr.setDetails(getParsedData(url).stream().map(detail -> {
+            QueryResponse qr = new QueryResponse(branch);
+
+            getParsedData(url).forEach(detail -> {
 
                 String iso = mapToISO(detail);
-                if (iso == null) return null;
+                if (iso == null) return;
 
                 QueryResponseDetail qrd = new QueryResponseDetail();
-                qrd.setQueryResponse(qr);
                 qrd.setIsoCode(iso);
                 qrd.setSalePrice(parse(detail.getVenta()));
                 qrd.setSaleTrend(detail.isVentaUp() ? 1 : -1);
                 qrd.setPurchasePrice(parse(detail.getCompra()));
                 qrd.setPurchaseTrend(detail.isCompraUp() ? 1 : -1);
 
-                return qrd;
-            }).filter(Objects::nonNull).collect(Collectors.toList()));
+                qr.addDetail(qrd);
+            });
 
             return qr;
         }).collect(Collectors.toList());
@@ -88,13 +84,12 @@ public class MaxiCambios implements Gatherer {
 
         log.info("Creating place {}", CODE);
 
-        Place p = new Place();
-        p.setName(CODE);
-        p.setCode(CODE);
+        Place place = new Place();
+        place.setName(CODE);
+        place.setCode(CODE);
 
 
         PlaceBranch main = new PlaceBranch();
-        main.setPlace(p);
         main.setName("Shopping Multiplaza Casa Central");
         main.setLatitude(-25.3167006);
         main.setLongitude(-57.572267);
@@ -105,7 +100,6 @@ public class MaxiCambios implements Gatherer {
         main.setRemoteCode("0");
 
         PlaceBranch cde = new PlaceBranch();
-        cde.setPlace(p);
         cde.setName("Casa Central CDE");
         cde.setLatitude(-25.5083135);
         cde.setLongitude(-54.6384264);
@@ -115,8 +109,8 @@ public class MaxiCambios implements Gatherer {
         cde.setRemoteCode("13");
 
 
-        p.setBranches(Arrays.asList(main, cde));
-        return p;
+        place.setBranches(Arrays.asList(main, cde));
+        return place;
 
     }
 

--- a/src/main/java/py/com/volpe/cotizacion/gatherer/MyD.java
+++ b/src/main/java/py/com/volpe/cotizacion/gatherer/MyD.java
@@ -13,8 +13,6 @@ import py.com.volpe.cotizacion.domain.Place;
 import py.com.volpe.cotizacion.domain.PlaceBranch;
 import py.com.volpe.cotizacion.domain.QueryResponse;
 import py.com.volpe.cotizacion.domain.QueryResponseDetail;
-import py.com.volpe.cotizacion.repository.PlaceRepository;
-import py.com.volpe.cotizacion.repository.QueryResponseRepository;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -33,13 +31,11 @@ public class MyD implements Gatherer {
 
     private static final String CODE = "MyD";
     private static final String URL = "https://www.mydcambios.com.py/?sucursal=%s";
-    private final PlaceRepository placeRepository;
-    private final QueryResponseRepository queryResponseRepository;
 
     @Override
-    public List<QueryResponse> doQuery() {
+    public List<QueryResponse> doQuery(Place p, List<PlaceBranch> branches) {
 
-        return get().getBranches().stream().map(branch -> {
+        return branches.stream().map(branch -> {
 
             QueryResponse qr = new QueryResponse(branch);
 
@@ -51,15 +47,10 @@ public class MyD implements Gatherer {
                             parse(data.getSalePrice()),
                             getISOName(data))));
 
-            return queryResponseRepository.save(qr);
+            return qr;
 
         }).collect(Collectors.toList());
 
-    }
-
-    @Override
-    public Place get() {
-        return placeRepository.findByCode(CODE).orElseGet(this::create);
     }
 
     @Override
@@ -68,7 +59,8 @@ public class MyD implements Gatherer {
     }
 
 
-    private Place create() {
+    @Override
+    public Place build() {
 
 
         log.info("Creating place MyD");
@@ -101,7 +93,7 @@ public class MyD implements Gatherer {
 
         p.setBranches(Arrays.asList(pb, villa, cde));
 
-        return placeRepository.save(p);
+        return p;
 
     }
 

--- a/src/main/java/py/com/volpe/cotizacion/gatherer/MyD.java
+++ b/src/main/java/py/com/volpe/cotizacion/gatherer/MyD.java
@@ -64,15 +64,15 @@ public class MyD implements Gatherer {
 
 
         log.info("Creating place MyD");
-        Place p = new Place("Cambios MyD", CODE);
+        Place place = new Place("Cambios MyD", CODE);
 
-        PlaceBranch pb = new PlaceBranch();
-        pb.setName("Casa Matriz");
-        pb.setRemoteCode("2");
-        pb.setPhoneNumber("021451377/9");
-        pb.setLatitude(-25.281474);
-        pb.setLongitude(-57.637259);
-        pb.setImage("https://www.mydcambios.com.py/uploads/sucursal/2/_principal_myd_cambios_matriz.jpg");
+        PlaceBranch matriz = new PlaceBranch();
+        matriz.setName("Casa Matriz");
+        matriz.setRemoteCode("2");
+        matriz.setPhoneNumber("021451377/9");
+        matriz.setLatitude(-25.281474);
+        matriz.setLongitude(-57.637259);
+        matriz.setImage("https://www.mydcambios.com.py/uploads/sucursal/2/_principal_myd_cambios_matriz.jpg");
 
 
         PlaceBranch villa = new PlaceBranch();
@@ -91,9 +91,9 @@ public class MyD implements Gatherer {
         cde.setLongitude(-54.639613);
         cde.setImage("https://www.mydcambios.com.py/uploads/sucursal/4/_principal_img_20160218_wa0060.jpg");
 
-        p.setBranches(Arrays.asList(pb, villa, cde));
+        place.setBranches(Arrays.asList(matriz, villa, cde));
 
-        return p;
+        return place;
 
     }
 

--- a/src/main/java/py/com/volpe/cotizacion/repository/PlaceRepository.java
+++ b/src/main/java/py/com/volpe/cotizacion/repository/PlaceRepository.java
@@ -11,5 +11,5 @@ import java.util.Optional;
  */
 public interface PlaceRepository extends JpaRepository<Place, Long> {
 
-	Optional<Place> findByCode(String code);
+    Optional<Place> findByCode(String code);
 }

--- a/src/main/resources/alberdi_branch_data.json
+++ b/src/main/resources/alberdi_branch_data.json
@@ -1,0 +1,72 @@
+{
+  "cde2" : {
+    "latitude" : -25.5095271,
+    "longitude" : -54.6485326,
+    "phoneNumber" : "(061) 571.540 / (061) 571.536",
+    "email" : null,
+    "image" : null,
+    "name" : "CDE KM 4",
+    "schedule" : "07:00 horas a 17:00 horas de Lunes a Viernes, 07:00 horas a 12:00 horas Sábados",
+    "remoteCode" : "cde2"
+  },
+  "sanlo" : {
+    "latitude" : -25.3459184,
+    "longitude" : -57.5151255,
+    "phoneNumber" : "(021) 571.215 / (021) 571.216",
+    "email" : null,
+    "image" : "https://lh5.googleusercontent.com/p/AF1QipM0yx3fvWQArt0kY6EwyaaAsgX1jYRy3OuIobjr=w408-h725-k-no",
+    "name" : "San Lorenzo",
+    "schedule" : "08:00 horas a 17:00 horas de Lunes a Viernes, 08:00 horas a 12:00 horas Sábados",
+    "remoteCode" : "sanlo"
+  },
+  "asuncion" : {
+    "latitude" : -25.281411,
+    "longitude" : -57.6375917,
+    "phoneNumber" : "(021) 447.003 / (021) 447.004",
+    "email" : "matriz@cambiosalberdi.com",
+    "image" : "https://lh5.googleusercontent.com/p/AF1QipMxA2Nv-mtjAzqti1pUgd_Bt3z8nfbBBizklGEw=w408-h244-k-no",
+    "name" : "Asunción",
+    "schedule" : "07:45 horas a 17:00 horas de Lunes a Viernes, 07:45 horas a 12:00 horas Sábados",
+    "remoteCode" : "asuncion"
+  },
+  "villamorra" : {
+    "latitude" : -25.2962143,
+    "longitude" : -57.5766948,
+    "phoneNumber" : "(021) 609.905 / (021) 609.906",
+    "email" : null,
+    "image" : "https://lh5.googleusercontent.com/p/AF1QipP9gq7gRfgXTFGdQFGJYWLZGq_9SSLJ_pKYN4Uk=w408-h306-k-no",
+    "name" : "Villa Morra",
+    "schedule" : "08:00 horas a 17:00 horas de Lunes a Viernes, 08:00 horas a 12:00 horas Sábados",
+    "remoteCode" : "villamorra"
+  },
+  "cde" : {
+    "latitude" : -25.5098204,
+    "longitude" : -54.6164127,
+    "phoneNumber" : "(061) 500.135 / (061) 500.417",
+    "email" : null,
+    "image" : null,
+    "name" : "Sucursal 1 CDE",
+    "schedule" : "07:00 horas a 17:00 horas de Lunes a Viernes, 07:00 horas a 12:00 horas Sábados",
+    "remoteCode" : "cde"
+  },
+  "salto" : {
+    "latitude" : -24.055276,
+    "longitude" : -54.3246485,
+    "phoneNumber" : "(046) 243.158 / (046) 243.159",
+    "email" : null,
+    "image" : null,
+    "name" : "Salto del Guairá",
+    "schedule" : "08:00 horas a 16:00 horas de Lunes a Viernes, 07:30 horas a 11:30 horas Sábados",
+    "remoteCode" : "salto"
+  },
+  "enc" : {
+    "latitude" : -27.3314553,
+    "longitude" : -55.8670186,
+    "phoneNumber" : "(071) 205.154 / (071) 205.120 / (071) 205.144",
+    "email" : null,
+    "image" : "https://lh5.googleusercontent.com/p/AF1QipOAtjZef_kGv14qJ4h68Rt4CKOxxwYXPJW30BUY=w408-h306-k-no",
+    "name" : "Encarnación",
+    "schedule" : "07:45 horas a 17:00 horas de Lunes a Viernes, 07:45 horas a 12:00 horas Sábados",
+    "remoteCode" : "enc"
+  }
+}

--- a/src/test/java/py/com/volpe/cotizacion/CotizacionAppTests.java
+++ b/src/test/java/py/com/volpe/cotizacion/CotizacionAppTests.java
@@ -5,12 +5,15 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+/**
+ * This only test if the application start.
+ */
 @RunWith(SpringRunner.class)
 @SpringBootTest
-public class DemoApplicationTests {
+public class CotizacionAppTests {
 
-	@Test
-	public void contextLoads() {
-	}
+    @Test
+    public void contextLoads() {
+    }
 
 }

--- a/src/test/java/py/com/volpe/cotizacion/CotizacionAppTests.java
+++ b/src/test/java/py/com/volpe/cotizacion/CotizacionAppTests.java
@@ -15,7 +15,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class CotizacionAppTests {
 
     @Autowired
-    GathererManager manager;
+    private GathererManager manager;
 
     @Test
     public void contextLoads() {

--- a/src/test/java/py/com/volpe/cotizacion/CotizacionAppTests.java
+++ b/src/test/java/py/com/volpe/cotizacion/CotizacionAppTests.java
@@ -1,7 +1,9 @@
 package py.com.volpe.cotizacion;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -12,8 +14,13 @@ import org.springframework.test.context.junit4.SpringRunner;
 @SpringBootTest
 public class CotizacionAppTests {
 
+    @Autowired
+    GathererManager manager;
+
     @Test
     public void contextLoads() {
+
+        Assert.assertNotNull(manager);
     }
 
 }

--- a/src/test/java/py/com/volpe/cotizacion/GathererManagerTest.java
+++ b/src/test/java/py/com/volpe/cotizacion/GathererManagerTest.java
@@ -67,7 +67,6 @@ public class GathererManagerTest {
         Mockito.when(second.doQuery(any(), any())).thenThrow(new AppException(400, "Invalid place"));
 
 
-
         GathererManager manager = new GathererManager(Arrays.asList(first, second), pr, qr);
 
         Assert.assertEquals(1, manager.doQuery(null).size());

--- a/src/test/java/py/com/volpe/cotizacion/gatherer/AlberdiTest.java
+++ b/src/test/java/py/com/volpe/cotizacion/gatherer/AlberdiTest.java
@@ -14,17 +14,12 @@ import py.com.volpe.cotizacion.domain.Place;
 import py.com.volpe.cotizacion.domain.PlaceBranch;
 import py.com.volpe.cotizacion.domain.QueryResponse;
 import py.com.volpe.cotizacion.domain.QueryResponseDetail;
-import py.com.volpe.cotizacion.repository.PlaceRepository;
-import py.com.volpe.cotizacion.repository.QueryResponseRepository;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.*;
-import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -34,12 +29,6 @@ import static org.mockito.Mockito.when;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class AlberdiTest {
-
-    @Mock
-    private PlaceRepository placeRepository;
-
-    @Mock
-    private QueryResponseRepository queryResponseRepository;
 
     @Mock
     private WSHelper wsHelper;
@@ -53,15 +42,13 @@ public class AlberdiTest {
         String data = IOUtils.toString(getClass().getResourceAsStream("alberdi_data.json"), "UTF-8");
 
         when(wsHelper.getDataWithoutSending(anyString())).thenReturn(data);
-        when(placeRepository.save(any())).thenAnswer(returnsFirstArg());
-        when(queryResponseRepository.save(any())).thenAnswer(returnsFirstArg());
     }
 
     @Test
     public void create() throws Exception {
 
 
-        Place created = alberdi.get();
+        Place created = alberdi.build();
 
         assertNotNull(created);
         assertNotNull(alberdi.getCode(), created.getCode());
@@ -85,19 +72,17 @@ public class AlberdiTest {
         try {
             alberdi.getParsedData();
             Assert.fail();
-        } catch(AppException ae) {
+        } catch (AppException ae) {
             assertEquals(500, ae.getNumber());
         }
     }
 
 
     @Test
-    public void doQuery() throws Exception {
-        Place place = alberdi.get();
-        when(placeRepository.findByCode(anyString())).thenReturn(Optional.of(place));
+    public void doQuery() {
+        Place place = alberdi.build();
 
-
-        List<QueryResponse> data = alberdi.doQuery();
+        List<QueryResponse> data = alberdi.doQuery(place, place.getBranches());
 
         assertEquals(7, data.size());
         for (QueryResponse qr : data) {


### PR DESCRIPTION
The JPA usage in the gatherers add an unnecessary complexity to the scraping
logic, this change allows a simple interface that only care about the
data extraction, and let the responsibility of the persist and data
handling to the GathererManager.