### PR TITLE
fix: Load with default currency

### DIFF
--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -245,7 +245,7 @@ export default new Vuex.Store<RootState>({
         },
 
         fetchCurrencyData: ({commit, dispatch, state}, currency: string = "USD") => {
-            if (state.current.currency === currency) {
+            if (state.current.currency !== currency) {
                 commit("setCurrency", currency);
             }
             const exchanges = (state as RootState).exchanges;


### PR DESCRIPTION
When we use a URL with a default currency (for example ?moneda=ARG) we
need to set the current currency on the store, this is done in the
LatestExchange component, on mount it check the url and set the store
state, but, because a bug in the store, the current currency wasn't
updated, so we were loading the correct currency, but we are not showing
it becaues the current was current.

This commit fixes the condition so when we load the requested currency
the current currency is updated.
